### PR TITLE
Fixing the broken link in README.md

### DIFF
--- a/examples/in-cluster-client-configuration/README.md
+++ b/examples/in-cluster-client-configuration/README.md
@@ -54,5 +54,5 @@ the `kubectl run` command and then run:
 
     kubectl delete deployment demo
 
-[sa]: https://kubernetes.io/docs/admin/authentication/#service-account-tokens
+[sa]: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#service-account-tokens
 [mk]: https://kubernetes.io/docs/getting-started-guides/minikube/


### PR DESCRIPTION
The Service Account Token link in the readme is broken and refers to a page that no longer exists. In this PR I updated the correct link in the readme.
